### PR TITLE
disable TARGET_HW_DISK_ENCRYPTION

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -94,7 +94,7 @@ BOARD_USES_QCNE := true
 TARGET_LDPRELOAD := libNimsWrap.so
 
 # Crypto
-TARGET_HW_DISK_ENCRYPTION := true
+# FDE works well w/o HW-based encryption flag
 TARGET_SWV8_DISK_ENCRYPTION := true
 
 # Dex


### PR DESCRIPTION
Full Disk Encryption works well without that flag, which activate non-working HW-based FDE.

some logs with TARGET_HW_DISK_ENCRYPTION:
`06-12 05:06:15.814   250   262 D Cryptfs : unmounting /data succeeded
06-12 05:06:15.816   250   262 I Cryptfs : keymaster module name is Keymaster OpenSSL HAL
06-12 05:06:15.816   250   262 I Cryptfs : keymaster version is 2
06-12 05:06:15.816   250   262 I Cryptfs : Found keymaster0 module, using keymaster0 API.
06-12 05:06:15.816   250   262 I Cryptfs : Using scrypt for cryptfs KDF
06-12 05:06:16.923  6996  6999 D BootAnimation: Use save memory method, maybe small fps in actual.
06-12 05:06:19.144   250   262 E         : Timed out waiting for QSEECom listeners..aborting FDE key operation
06-12 05:06:19.153   250   262 I         : Keymaster version is not 1.0
06-12 05:06:19.153   250   262 D         : HW based disk encryption is enabled 
06-12 05:06:20.156   250   262 E         : Timed out waiting for QSEECom listeners..aborting FDE key operation
06-12 05:06:20.156   250   262 E Cryptfs : Error enabling encryption after framework is shutdown, no data changed, restarting system`

some logs W/O TARGET_HW_DISK_ENCRYPTION
`06-30 12:53:28.042   235   249 D Cryptfs : unmounting /data succeeded
06-30 12:53:28.044   235   249 I Cryptfs : keymaster module name is Keymaster OpenSSL HAL
06-30 12:53:28.044   235   249 I Cryptfs : keymaster version is 2
06-30 12:53:28.044   235   249 I Cryptfs : Found keymaster0 module, using keymaster0 API.
06-30 12:53:28.045   235   249 I Cryptfs : Using scrypt for cryptfs KDF
06-30 12:53:30.421   235   249 D Cryptfs : Just triggered post_fs_data
06-30 12:53:30.521   235   249 D Cryptfs : post_fs_data done
06-30 12:53:32.525   235   249 D Cryptfs : Just triggered restart_min_framework
06-30 12:53:32.525   235   249 I Cryptfs : Using scrypt for cryptfs KDF
06-30 12:53:34.296   235   249 I Cryptfs : Enabling support for allow_discards in dmcrypt.
06-30 12:53:34.296   235   249 I Cryptfs : target_type = crypt
06-30 12:53:34.296   235   249 I Cryptfs : real_blk_name = /dev/block/bootdevice/by-name/userdata, extra_params = 1 allow_discards
06-30 12:53:34.299   235   247 D vold    : Disk at 254:1 changed
06-30 12:53:34.307   235   249 I Cryptfs : Encrypting ext4 filesystem in place...
06-30 12:53:34.307   235   249 I Cryptfs : Encrypting group 0
06-30 12:53:34.312   235   249 I Cryptfs : Encrypting from sector 0
06-30 12:53:34.358   235   249 I Cryptfs : Encrypted to sector 419840
06-30 12:53:34.358   235   249 I Cryptfs : Encrypting from sector 524288
06-30 12:53:34.414   235   249 I Cryptfs : Encrypted to sector 786432
06-30 12:53:34.414   235   249 I Cryptfs : Encrypting from sector 1048576
`