### PR TITLE
disable TARGET_HW_DISK_ENCRYPTION

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -91,7 +91,7 @@ BOARD_HARDWARE_CLASS += \
     $(VENDOR_PATH)/cmhw
 
 # Crypto
-TARGET_HW_DISK_ENCRYPTION := true
+# FDE works only in software mode, disable HW.
 TARGET_SWV8_DISK_ENCRYPTION := true
 
 # Dex


### PR DESCRIPTION
FDE works only in software mode, we can disable HW encryption flag to make it working.